### PR TITLE
Assert that let-flow bindings are unique

### DIFF
--- a/src/manifold/deferred.clj
+++ b/src/manifold/deferred.clj
@@ -1308,6 +1308,7 @@
         [_ bindings & body] (walk/walk-exprs (constantly false) nil ignore-symbol? `(let ~bindings ~@body))
         locals              (keys (compiler/locals))
         vars                (->> bindings (partition 2) (map first))
+        _                   (assert (apply distinct? vars) "Let binding vars must be unique.")
         marker              (gensym)
         vars'               (->> vars (concat locals) (map #(vary-meta % assoc marker true)))
         gensyms             (repeatedly (count vars') gensym)


### PR DESCRIPTION
Without this the following can happen:

```clojure
@(let-flow [x "cat"
           x "dog"]
  x)
=> "cat"
```

While possible to update the macro to fix this, it's easier and more reliable to throw an
error during macro-expansion.